### PR TITLE
feat: add difficulty and median time data to the block page

### DIFF
--- a/src/app/block/[block]/_components/block_details/index.tsx
+++ b/src/app/block/[block]/_components/block_details/index.tsx
@@ -3,14 +3,6 @@ import Image from "next/image";
 export const BlockDetails = ({ data }: any) => {
   return (
     <div className="bg-white py-4 h-full w-full">
-      <div className="flex items-center justify-between">
-        <div className="w-1/2 text-center py-2 border-b-2 border-primary-100 font-bold whitespace-nowrap overflow-ellipsis overflow-hidden">More info</div>
-        <div
-          className={`w-1/2 text-center py-2 border-b-2 border-secondary-100 text-secondary-100 font-bold whitespace-nowrap overflow-ellipsis overflow-hidden`}
-        >
-          Consensus data (coming soon)
-        </div>
-      </div>
       <div className="grid md:grid-cols-2 grid-cols-1 gap-4">
         {data.map((item: any) => (
           <div key={item.title} className="grid grid-cols-2 gap-4 px-4 py-2">

--- a/src/app/block/[block]/page.tsx
+++ b/src/app/block/[block]/page.tsx
@@ -183,7 +183,7 @@ export default async function Block({
           <BlockDetails
             data={[
               { title: "Size", value: "-", icon: icon_info },
-              { title: "Difficulty", value: "-", icon: icon_info },
+              { title: "Difficulty", value: data.info.target_difficulty, icon: icon_info },
               {
                 title: "Merkle root",
                 value: data?.info?.merkle_root,
@@ -191,7 +191,7 @@ export default async function Block({
               },
               { title: "Version", value: "-", icon: icon_info },
               { title: "Bits", value: "-", icon: icon_info },
-              { title: "Median time", value: "-", icon: icon_info },
+              { title: "Median time", value: data?.info?.median_time ? formatDate(data.info.median_time) : "-", icon: icon_info },
             ]}
           />
         </div>


### PR DESCRIPTION
This Pull Request introduces enhancements to the block API and UI. It adds new functionality to calculate and display the median time and target difficulty of blocks while removing deprecated UI components.
## Main Changes:
- API Enhancements:
  - Added a recursive function getBlocksRecursive to fetch previous blocks recursively with a limit.
  - Implemented a calculateMedianTimePast function to compute the median time from block timestamps.
  - Included target_difficulty and median_time in the block API response.
- UI Updates:
  - Removed unused "More info" and "Consensus data (coming soon)" sections in the BlockDetails component.
  - Updated block page UI to display target_difficulty and median_time values dynamically based on fetched data.