### PR TITLE
fix: remove APY display from homepage summary

### DIFF
--- a/src/app/(homepage)/_components/summary/index.tsx
+++ b/src/app/(homepage)/_components/summary/index.tsx
@@ -1,36 +1,16 @@
 import { HeadingBox } from "@/app/(homepage)/_components/heading_box";
 import community from "@/app/(homepage)/_icons/24px/community.svg";
 import txs from "@/app/(homepage)/_icons/24px/txs.svg";
-import fee from "@/app/(homepage)/_icons/24px/fee.svg";
 import { Icon } from "@/app/_components/heading_box/icon";
 
 export function Summary({ data, data_transaction }: { data: any; data_transaction: number }) {
   return (
     <>
-      <div className="col-span-2">
-        <HeadingBox
-          title={`${data.total_apy}%`}
-          subtitle="Current APY"
-          icon={<Icon src={fee} />}
-          button={{ label: "Start staking", link: "/pools" }}
-          iconTooltip="Current APY"
-        />
+      <div>
+        <HeadingBox title={data.validators_count} subtitle="Validators" icon={<Icon src={community} />} iconTooltip="Validators" />
       </div>
       <div>
-        <HeadingBox
-          title={data.validators_count}
-          subtitle="Validators"
-          icon={<Icon src={community} />}
-          iconTooltip="Validators"
-        />
-      </div>
-      <div>
-        <HeadingBox
-          title={data_transaction}
-          subtitle="Total transactions"
-          icon={<Icon src={txs} />}
-          iconTooltip="Total transactions"
-        />
+        <HeadingBox title={data_transaction} subtitle="Total transactions" icon={<Icon src={txs} />} iconTooltip="Total transactions" />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

- Remove the "Current APY" metric box from the homepage summary section
- Remove the "Start staking" call-to-action button that accompanied it
- The Validators and Total Transactions stats remain unchanged